### PR TITLE
Fixed some bugs with AwaitObservable

### DIFF
--- a/src/FSharp.AsyncExtensions.fsproj
+++ b/src/FSharp.AsyncExtensions.fsproj
@@ -11,6 +11,8 @@
     <AssemblyName>FSharp.AsyncExtensions</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <Name>FSharp.AsyncExtensions</Name>
+    <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
+    <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,8 +34,19 @@
     <WarningLevel>3</WarningLevel>
     <DocumentationFile>bin\Release\FSharp.AsyncExtensions.XML</DocumentationFile>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath32)\FSharp\1.0\Microsoft.FSharp.Targets" Condition="!Exists('$(MSBuildBinPath)\Microsoft.Build.Tasks.v4.0.dll')" />
-  <Import Project="$(MSBuildExtensionsPath32)\..\Microsoft F#\v4.0\Microsoft.FSharp.Targets" Condition=" Exists('$(MSBuildBinPath)\Microsoft.Build.Tasks.v4.0.dll')" />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '11.0'">
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PostBuildEvent>copy $(ProjectDir)$(OutDir)\FSharp.AsyncExtensions.* $(ProjectDir)..\bin</PostBuildEvent>
   </PropertyGroup>
@@ -55,8 +68,10 @@ nuget pack $(ProjectDir)..\bin\release\FSharp.AsyncExtensions.dll.nuspec
     <Compile Include="IO.fs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>True</Private>
+    </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />

--- a/src/FSharp.AsyncExtensions.sln
+++ b/src/FSharp.AsyncExtensions.sln
@@ -1,8 +1,8 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.AsyncExtensions", "FSharp.AsyncExtensions.fsproj", "{EDE1812B-5A62-410A-9553-02499CF29317}"
-EndProject
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Misc", "Misc", "{8406B0C7-14A3-42F1-AC7A-EE26C0A9F15E}"
 	ProjectSection(SolutionItems) = preProject
 		..\License.markdown = ..\License.markdown
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{DD79
 		..\samples\StockStream.fsx = ..\samples\StockStream.fsx
 		..\samples\WebProxy.fsx = ..\samples\WebProxy.fsx
 	EndProjectSection
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.AsyncExtensions", "FSharp.AsyncExtensions.fsproj", "{EDE1812B-5A62-410A-9553-02499CF29317}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Observable.fs
+++ b/src/Observable.fs
@@ -89,39 +89,44 @@ module ObservableExtensions =
     /// Behaves like AwaitObservable, but calls the specified guarding function
     /// after a subscriber is registered with the observable.
     static member GuardedAwaitObservable (ev1:IObservable<'T1>) guardFunction =
-      synchronize (fun f ->
-        Async.FromContinuations((fun (cont,econt,ccont) -> 
-          let rec finish cont value = 
-            remover.Dispose()
-            f (fun () -> cont value)
-          and remover : IDisposable = 
-            ev1.Subscribe
-              ({ new IObserver<_> with
-                   member x.OnNext(v) = finish cont v
-                   member x.OnError(e) = finish econt e
-                   member x.OnCompleted() = 
-                      let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
-                      finish ccont (new System.OperationCanceledException(msg)) }) 
-          guardFunction() )))
+      async {
+        let! token = Async.CancellationToken // capture the current cancellation token
+        return! Async.FromContinuations(fun (cont, econt, ccont) ->
+          // start a new mailbox processor which will await the result
+          Agent.Start((fun (mailbox : Agent<Choice<'T1, exn, OperationCanceledException>>) ->
+            async {
+              // register a callback with the cancellation token which posts a cancellation message
+              #if NET40
+              use __ = token.Register((fun _ ->
+                  mailbox.Post (Choice3Of3 (new OperationCanceledException "The opeartion was cancelled."))))
+              #else
+              use __ = token.Register((fun _ ->
+                  mailbox.Post (Choice3Of3 (new OperationCanceledException "The opeartion was cancelled."))), null)
+              #endif
+          
+              // subscribe to the observable: if an error occurs post an error message and post the result otherwise
+              use __ = 
+                ev1.Subscribe({ new IObserver<'T1> with
+                    member __.OnNext result = mailbox.Post (Choice1Of3 result)
+                    member __.OnError exn = mailbox.Post (Choice2Of3 exn)
+                    member __.OnCompleted () =
+                        let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
+                        mailbox.Post (Choice3Of3 (new OperationCanceledException(msg))) })
+              
+              guardFunction() // call the guard function
+
+              // wait for the first of these messages and call the appropriate continuation function
+              let! message = mailbox.Receive()
+              match message with
+              | Choice1Of3 reply -> cont reply
+              | Choice2Of3 exn -> econt exn
+              | Choice3Of3 exn -> ccont exn })) |> ignore) }
 
     /// Creates an asynchronous workflow that will be resumed when the 
     /// specified observables produces a value. The workflow will return 
     /// the value produced by the observable.
     static member AwaitObservable(ev1:IObservable<'T1>) =
-      synchronize (fun f ->
-        Async.FromContinuations((fun (cont,econt,ccont) -> 
-          let rec finish cont value = 
-            remover.Dispose()
-            f (fun () -> cont value)
-          and remover : IDisposable = 
-            ev1.Subscribe
-              ({ new IObserver<_> with
-                   member x.OnNext(v) = finish cont v
-                   member x.OnError(e) = finish econt e
-                   member x.OnCompleted() = 
-                      let msg = "Cancelling the workflow, because the Observable awaited using AwaitObservable has completed."
-                      finish ccont (new System.OperationCanceledException(msg)) }) 
-          () )))
+      Async.GuardedAwaitObservable ev1 ignore
   
     /// Creates an asynchronous workflow that will be resumed when the 
     /// first of the specified two observables produces a value. The 


### PR DESCRIPTION
The original implementation of AwaitObservable doesn't perform well when the workflow is cancelled before the observable produces a result. This was fixed in [this PR](https://github.com/anton-pt/fsharpx/commit/12e93c85ac3755cdb324c9e24cb1b4b332fb1002) on the fsharpx project. However this implementation would call multiple continuation functions for hot observables. Details on [stack overflow](http://stackoverflow.com/questions/28250201/fsharpx-async-awaitobservable-does-not-call-cancellation-continuation). The implementation here fixes the issue, although I'm not sure it's optimal.
